### PR TITLE
Support 3 recently released versions of base

### DIFF
--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                base-noprelude
-version:             4.16.0.0
+version:             4.16.1.0
 
 synopsis:            "base" package sans "Prelude" module
 homepage:            https://github.com/Holmusk/base-noprelude
@@ -14,7 +14,7 @@ build-type:          Simple
 description:
     This package simplifies defining custom "Prelude"s without having
     to use @-XNoImplicitPrelude@ by re-exporting the full module-hierarchy of
-    the [base-4.16.0.0](https://hackage.haskell.org/package/base-4.16.0.0)
+    the [base-4.16.1.0](https://hackage.haskell.org/package/base-4.16.1.0)
     package /except/ for the "Prelude" module.
     .
     An usage example for such a "Prelude"-replacement is available with
@@ -35,10 +35,10 @@ source-repository head
     location: https://github.com/Holmusk/base-noprelude.git
 
 library
-    build-depends:       base ==4.16.0.0
+    build-depends:       base ==4.16.1.0
     default-language:    Haskell2010
 
-    -- re-exported modules copied from base-4.16.0.0's exposed-modules
+    -- re-exported modules copied from base-4.16.1.0's exposed-modules
     reexported-modules:
       , Control.Applicative
       , Control.Arrow

--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                base-noprelude
-version:             4.15.1.0
+version:             4.16.0.0
 
 synopsis:            "base" package sans "Prelude" module
 homepage:            https://github.com/Holmusk/base-noprelude
@@ -14,7 +14,7 @@ build-type:          Simple
 description:
     This package simplifies defining custom "Prelude"s without having
     to use @-XNoImplicitPrelude@ by re-exporting the full module-hierarchy of
-    the [base-4.15.1.0](https://hackage.haskell.org/package/base-4.15.1.0)
+    the [base-4.16.0.0](https://hackage.haskell.org/package/base-4.16.0.0)
     package /except/ for the "Prelude" module.
     .
     An usage example for such a "Prelude"-replacement is available with
@@ -35,10 +35,10 @@ source-repository head
     location: https://github.com/Holmusk/base-noprelude.git
 
 library
-    build-depends:       base ==4.15.1.0
+    build-depends:       base ==4.16.0.0
     default-language:    Haskell2010
 
-    -- re-exported modules copied from base-4.15.1.0's exposed-modules
+    -- re-exported modules copied from base-4.16.0.0's exposed-modules
     reexported-modules:
       , Control.Applicative
       , Control.Arrow
@@ -107,6 +107,7 @@ library
       , Data.Type.Bool
       , Data.Type.Coercion
       , Data.Type.Equality
+      , Data.Type.Ord
       , Data.Typeable
       , Data.Unique
       , Data.Version
@@ -136,6 +137,7 @@ library
       , Foreign.Storable
       , GHC.Arr
       , GHC.Base
+      , GHC.Bits
       , GHC.ByteOrder
       , GHC.Char
       , GHC.Clock
@@ -227,7 +229,9 @@ library
       , GHC.Storable
       , GHC.TopHandler
       , GHC.TypeLits
+      , GHC.TypeLits.Internal
       , GHC.TypeNats
+      , GHC.TypeNats.Internal
       , GHC.Unicode
       , GHC.Weak
       , GHC.Word

--- a/base-noprelude.cabal
+++ b/base-noprelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                base-noprelude
-version:             4.15.0.0
+version:             4.15.1.0
 
 synopsis:            "base" package sans "Prelude" module
 homepage:            https://github.com/Holmusk/base-noprelude
@@ -14,7 +14,7 @@ build-type:          Simple
 description:
     This package simplifies defining custom "Prelude"s without having
     to use @-XNoImplicitPrelude@ by re-exporting the full module-hierarchy of
-    the [base-4.15.0.0](https://hackage.haskell.org/package/base-4.15.0.0)
+    the [base-4.15.1.0](https://hackage.haskell.org/package/base-4.15.1.0)
     package /except/ for the "Prelude" module.
     .
     An usage example for such a "Prelude"-replacement is available with
@@ -35,10 +35,10 @@ source-repository head
     location: https://github.com/Holmusk/base-noprelude.git
 
 library
-    build-depends:       base ==4.15.0.0
+    build-depends:       base ==4.15.1.0
     default-language:    Haskell2010
 
-    -- re-exported modules copied from base-4.15.0.0's exposed-modules
+    -- re-exported modules copied from base-4.15.1.0's exposed-modules
     reexported-modules:
       , Control.Applicative
       , Control.Arrow


### PR DESCRIPTION
3 separate commits, each of them containing bump to one of the 3 more recent versions of base.
Be careful and don't squash merge it - we need separate commits so anyone can depend on git hash containing particular version.